### PR TITLE
assign address space to legalized returned-array value test

### DIFF
--- a/source/slang/slang-ir-legalize-array-return-type.cpp
+++ b/source/slang/slang-ir-legalize-array-return-type.cpp
@@ -18,7 +18,7 @@ void makeFuncReturnViaOutParam(IRBuilder& builder, IRFunc* func)
     {
         paramTypes.add(funcType->getParamType(i));
     }
-    auto outParamType = builder.getOutType(funcType->getResultType());
+    auto outParamType = builder.getPtrType(kIROp_OutType, arrayType, AddressSpace::ThreadLocal);
     paramTypes.add(outParamType);
 
     auto newFuncType = builder.getFuncType(paramTypes, builder.getVoidType());

--- a/tests/bugs/gh-2959.slang
+++ b/tests/bugs/gh-2959.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF): -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE:-slang -shaderobj -mtl
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-slang -shaderobj -mtl
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/metal/groupshared-static-array-1.slang
+++ b/tests/metal/groupshared-static-array-1.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF): -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE:-slang -shaderobj -mtl
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-slang -shaderobj -mtl
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/metal/groupshared-static-array-1.slang
+++ b/tests/metal/groupshared-static-array-1.slang
@@ -4,14 +4,15 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
-static uint g_values[2] = { 0, 1 };
+static groupshared uint g_values[2] = { 0, 1 };
 
 [numthreads(2, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-	uint tid = dispatchThreadID.x;
-
+    uint tid = dispatchThreadID.x;
+    g_values[tid] += 1;
+    AllMemoryBarrier();
 	outputBuffer[tid] = g_values[tid];
-    // BUF: 0
-    // BUF: 1
+    // BUF: 2
+    // BUF: 3
 }

--- a/tests/metal/groupshared-static-array-2.slang
+++ b/tests/metal/groupshared-static-array-2.slang
@@ -1,5 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF): -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE:-slang -shaderobj -mtl
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-slang -shaderobj -mtl
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/metal/groupshared-static-array-2.slang
+++ b/tests/metal/groupshared-static-array-2.slang
@@ -1,0 +1,42 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF): -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE:-slang -shaderobj -mtl
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+static groupshared uint g_values[2] = { 0, 1 };
+static uint g_altValues[2] = { 2, 3 };
+
+static groupshared uint g_valuesReturned[2];
+static uint g_altValuesReturned[2];
+
+uint[2] maybeGroupSharedReturn(uint id)
+{
+    if (id == 0)
+    {
+        return g_values;
+    }
+    else
+    {
+        return g_altValues;
+    }
+}
+
+[numthreads(2, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint tid = dispatchThreadID.x;
+    if (tid == 0)
+    {
+        g_valuesReturned[tid] = maybeGroupSharedReturn(tid)[tid];
+    }
+    else
+    {
+        g_altValuesReturned[tid] = maybeGroupSharedReturn(tid)[tid];
+    }
+
+    AllMemoryBarrierWithGroupSync();
+    outputBuffer[tid] = g_valuesReturned[tid];
+    // BUF: 0
+    // BUF: 3
+}


### PR DESCRIPTION
returned value is `ThreadLocal` since returning an array is expected to be threadlocal or promoted to thread group memory

test