### PR TITLE
Infer type with constant folded objects - TEST

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1836,6 +1836,8 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
 
             varDecl->initExpr = initExpr;
             varDecl->type.type = initExpr->type;
+
+            varDecl->setCheckState(DeclCheckState::DefinitionChecked);
             _validateCircularVarDefinition(varDecl);
         }
 

--- a/tests/bugs/infer-var-type-constant-folding.slang
+++ b/tests/bugs/infer-var-type-constant-folding.slang
@@ -1,0 +1,15 @@
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -emit-spirv-directly
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+//BUF: 11
+
+RWStructuredBuffer<int> outputBuffer;
+
+static const let C = float(3);
+static const let D = int(4+4+int(C));
+
+void computeMain()
+{
+    outputBuffer[0] = D;
+}


### PR DESCRIPTION
Problem:
* Infering type with `let` while using constant-foldable object's means we run in a circular loop of `ensureDecl`.

Changes:
* If we constant-fold we effectively are ready to check definition. If we are not a constant to fold, we run `setCheckState` after anyways.